### PR TITLE
OpenRunningTimeout + FIX to events_per_lumi casting

### DIFF
--- a/wmcontrol.py
+++ b/wmcontrol.py
@@ -1158,7 +1158,7 @@ def build_parser():
   parser.add_option('--process-string', help='string to be added in the name of the request' , dest='process_string',default='')
   parser.add_option('--processing-string', help='process string do be added in the second part of dataset name' , dest='processing_string',default='') 
   parser.add_option('--batch', help='Include in the WF batch number' , dest='batch')
-  parser.add_option('--open-running-timeout', help='how long(finite) a request should remain opened, in seconds' , dest='open_running_timeout')
+  parser.add_option('--open-running-timeout', help='how long(finite) a request should remain opened, in seconds' , dest='open_running_timeout',default=43200)
   
   # Param to be inline with prep wmcontrol
   parser.add_option('--campaign', help='The name of the era (was: campaign; NO LNOGER)' , dest='campaign', default = "")


### PR DESCRIPTION
- OpenRunningTimeout: settable, while it was only default value. 
- FIX to events_per_lumi casting, which had effect only when not set and falling on default value

TESTS performed: 

wmcontrol.py --req_file=/afs/cern.ch/user/f/franzoni/public/4antanas/test-GF-2014-11-11.conf --test
wmcontrol.py --req_file=/afs/cern.ch/user/f/franzoni/public/4antanas/test-GF-2014-11-11.conf

wmcontrol.py --release CMSSW_6_2_5 --arch slc5_amd64_gcc472 --conditions POSTLS162_V1::All --version 1 --priority 85000 --time-event 226.13 --size-event 1588 --memory 2300 --request-type MonteCarlo --step1-docID f096a17eea988936256e58fbe02657d4 --request-id B2G-Fall13-00012 --user pdmvserv  --group ppd  --batch 00133 --filter-eff 1.0 --events-per-lumi 100.0 --number-events 75000 --primary-dataset LQLQToTopTau_M_300_Tune4C_13TeV_pythia8_tauola --processing-string POSTLS162_V1 --events-per-lumi 10 --open-running-timeout 56778 --test

wmcontrol.py --release CMSSW_6_2_5 --arch slc5_amd64_gcc472 --conditions POSTLS162_V1::All --version 1 --priority 85000 --time-event 226.13 --size-event 1588 --memory 2300 --request-type MonteCarlo --step1-docID f096a17eea988936256e58fbe02657d4 --request-id B2G-Fall13-00012 --user pdmvserv  --group ppd  --batch 00133 --filter-eff 1.0 --events-per-lumi 100.0 --number-events 75000 --primary-dataset LQLQToTopTau_M_300_Tune4C_13TeV_pythia8_tauola --processing-string POSTLS162_V1 --events-per-lumi 10 --open-running-timeout 56778
