### PR TITLE
fix: check presence of key 'RequestNumEvents' before using it;

### DIFF
--- a/wmcontrol.py
+++ b/wmcontrol.py
@@ -459,7 +459,7 @@ def loop_and_submit(cfg):
           ##if we have a taskChain and its First task has inputDS, we do splitting algo
           ##TO-DO: move to separate method so we would not need to duplicate code
           if 'InputDataset' in params['Task1']:
-              if params['Task1']['InputDataset'] != '' and params['Task1']['RequestNumEvents']:
+              if params['Task1']['InputDataset'] != '' and 'RequestNumEvents' in params['Task1'] and params['Task1']['RequestNumEvents']:
                   if test_mode:
                       t = time.time()
                   espl = helper.SubsetByLumi(params['Task1']['InputDataset'],


### PR DESCRIPTION
 this bug was already reported by @jmduarte here: 
https://github.com/cms-PdmV/wmcontrol/commit/0a2352e7866a61cf41fb31afa334f4f268f8a415#commitcomment-10043311

the bug getting fixed here
only affected taskchains being submitted with input dataset 
via wmcontrol.py