### PR TITLE
support for AlCa validation 

### DIFF
--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -422,7 +422,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
     cmssw_command = "cd %s; eval `scramv1 runtime -sh`; cd -"%options.hltCmsswDir
     upload_command = "wmupload.py -u %s -g PPD -l %s %s"% (os.getenv('USER'),cfgname,cfgname)
     execme(cmssw_command + '; ' + driver_command + '; ' + upload_command)
-    
+
     base=None
     if 'base' in details:
       base=details['base']
@@ -437,7 +437,8 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                       "--no_exec " +\
                       "-n 100 "
       execme(driver_command)
-      
+
+    label=cfgname.lower().replace('.py','')[0:5]
     recodqm = None
     if 'recodqm' in details:
       recodqm=details['recodqm']
@@ -482,18 +483,17 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                       "--filetype DQM " +\
                       "--conditions %s "%options.basegt +\
                       "--filein=file:%s "%filein +\
-                      "--python_filename=step4_HARVESTING.py " +\
+                      "--python_filename=step4_%s_HARVESTING.py "%label +\
                       "--no_exec " +\
                       "-n 100 "
                       
       if options.recoCmsswDir:
         cmssw_command = "cd %s; eval `scramv1 runtime -sh`; cd -"%options.recoCmsswDir
-        upload_command = "wmupload.py -u %s -g PPD -l %s %s"% (os.getenv('USER'),'step4_HARVESTING.py','step4_HARVESTING.py')
+        upload_command = "wmupload.py -u %s -g PPD -l %s %s"% (os.getenv('USER'),'step4_%s_HARVESTING.py'%label,'step4_%s_HARVESTING.py'%label)
         execme(cmssw_command + '; ' + driver_command + '; ' + upload_command)
       else:
         execme(driver_command)
-    else:      
-      label=cfgname.lower().replace('.py','')  
+    else:
       if options.Type.find("ALCA")!=-1:
           filein = "%s_RAW2DIGI_L1Reco_RECO_ALCA_DQM_inDQM.root"%details['reqtype']
       else:
@@ -590,7 +590,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                    'cfg_path = REFERENCE.py\n' +\
                    'req_name = %s_reference_RelVal_%s\n'%(details['reqtype'],options.run[0]) +\
                    'globaltag = %s\n'%(refgtshort) +\
-                   'harvest_cfg=step4_reference_HARVESTING.py\n\n'
+                   'harvest_cfg=step4_refer_HARVESTING.py\n\n' # this is ugly and depends on [0:5]; can't be easliy fixed w/o reorganization
 
   task=2
   print confCondList
@@ -605,7 +605,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
         task+=1
         continue
       elif recodqm:
-        label=cfgname.lower().replace('.py','')[0:3]
+        label=cfgname.lower().replace('.py','')[0:5]
         wmcconf_text+='\n\n[%s_%s]\n' %(details['reqtype'],label) +\
                        'keep_step%d = True\n'%task +\
                        'time_event = 1\n' +\
@@ -624,7 +624,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                        'step%d_timeevent = 10\n'%task
         if options.recoRelease:
           wmcconf_text+='step%d_release = %s \n'%(task,options.recoRelease)
-        wmcconf_text+='harvest_cfg=step4_HARVESTING.py\n\n'
+        wmcconf_text+='harvest_cfg=step4_%s_HARVESTING.py\n\n'%label
       else:
         continue
 
@@ -637,7 +637,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
       task+=1
     elif recodqm:
       if "REFERENCE" in cfgname: continue
-      label=cfgname.lower().replace('.py','')[0:7]
+      label=cfgname.lower().replace('.py','')[0:5]
       wmcconf_text+='\n\n[%s_%s]\n' %(details['reqtype'],label) +\
                      'keep_step%d = True\n'%task +\
                      'time_event = 1\n' +\
@@ -656,9 +656,9 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                      'step%d_timeevent = 10\n'%task
       if options.recoRelease:
         wmcconf_text+='step%d_release = %s \n'%(task,options.recoRelease)
-      wmcconf_text+='harvest_cfg=step4_HARVESTING.py\n\n'
+      wmcconf_text+='harvest_cfg=step4_%s_HARVESTING.py\n\n'%label
     else:
-      label=cfgname.lower().replace('.py','')[0:7]
+      label=cfgname.lower().replace('.py','')[0:5]
       wmcconf_text+='\n\n[%s_%s]\n' %(details['reqtype'],label) +\
                      'keep_step1 = True\n' +\
                      'time_event = 10\n' +\

--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -696,7 +696,11 @@ def printInfo(options):
     f = open(hltFilename)
     menu = f.readline()
     menu = menu.replace('\n','').replace('# ','')
-  
+    menulist = menu.split()
+    hltCmsswVersion = (options.hltCmsswDir).split('/')
+    menulist[-1] = '(%s)'%(hltCmsswVersion[-1]) 
+    menu = menulist[0] + " " + menulist[-1]
+
   matched=re.match("(.*),(.*),(.*)",options.newgt)
   if matched: 
     newgtshort=matched.group(1)

--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -571,7 +571,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
   for ds in options.ds:
     wmcconf_text+='"%s" : [%s],\n '%(ds, ','.join(options.run+ map(lambda s :'"%s"'%(s),allRunsAndBlocks[ds])))
   wmcconf_text+='}\n'
-  wmcconf_text+='enableharvesting = 1\n'
+  wmcconf_text+='enableharvesting = True\n'
   wmcconf_text+='dqmuploadurl = https://cmsweb.cern.ch/dqm/relval\n\n'
 
   if base:

--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -571,6 +571,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
   for ds in options.ds:
     wmcconf_text+='"%s" : [%s],\n '%(ds, ','.join(options.run+ map(lambda s :'"%s"'%(s),allRunsAndBlocks[ds])))
   wmcconf_text+='}\n'
+  wmcconf_text+='enableharvesting = 1\n'
   wmcconf_text+='dqmuploadurl = https://cmsweb.cern.ch/dqm/relval\n\n'
 
   if base:

--- a/modules/wma.py
+++ b/modules/wma.py
@@ -211,7 +211,7 @@ def makeRequest(url,params,encodeDict=False):
     conn.request("POST",  "/reqmgr/create/makeSchema", encodedParams, headers)
     response = conn.getresponse()
     data = response.read()
-    if response.status >= 400:
+    if response.status != 303:
         print 'could not post request with following parameters:'
         pprint.pprint( params )
         print

--- a/wmcontrol.py
+++ b/wmcontrol.py
@@ -1052,7 +1052,7 @@ def build_params_dict(section,cfg):
 
   if harvest_docID and request_type!="DQMHarvest":
       ##setup automatic harvesting
-      params.update({"EnableHarvesting" : 0,
+      params.update({"EnableHarvesting" : cfg.get_param('enableharvesting','0',section),
                      "DQMUploadUrl" : cfg.get_param('dqmuploadurl','https://cmsweb.cern.ch/dqm/offline',section),
                      "DQMConfigCacheID" : harvest_docID})
 
@@ -1138,6 +1138,7 @@ def build_parser():
   parser.add_option('--wmtest', help='To inject requests to the cmsweb test bed', action='store_true' , dest='wmtest')
   parser.add_option('--wmtesturl', help='To inject to a specific testbed', dest='wmtesturl', default='cmsweb-testbed.cern.ch')
   parser.add_option('--dqmuploadurl', help='ulr of the DQM GUI instance where DQM will be uploaded', dest='dqmuploadurl', default='https://cmsweb.cern.ch/dqm/offline')
+  parser.add_option('--enableharvesting', help='activate (1) or not (0) the automatic DQM harvesting', dest='enableharvesting', default='0')
   parser.add_option('--includeparents', help='Include parents', action='store_true' , dest='includeparents')
   parser.add_option('--req_name', help='Set the name of the request', dest='req_name')
   parser.add_option('--process-string', help='string to be added in the name of the request' , dest='process_string',default='')


### PR DESCRIPTION
hello,

we would like to merge on top of the PdmV master
the developments carried out to support the AlCa weekly validation in 2016.

Most of the changes don't touch PdmV-relevant code (condDatasetSubmitter.py)

The only changes to wmcontrol are for:
- introducing task chain submission, with multiple step
- making parameters in wmcontrol.py configurable via .conf file

The content of this PR has been used to successfully submit a recent set of relvals:
https://hypernews.cern.ch/HyperNews/CMS/get/dataopsrequests/14555.html
https://hypernews.cern.ch/HyperNews/CMS/get/relval/5785.html

cheers,
@mmusich 