### PR TITLE
Decides how many WFs (1 or 2) to run for PROMPT

### DIFF
--- a/relval_submit.py
+++ b/relval_submit.py
@@ -120,6 +120,9 @@ I will ask you some questions to fill the metadata file. For some of the questio
                 if 'HLT+RECO' in type:
                     hlt_release = getInput('CMSSW_7_4_9_patch1', '\nWhich CMSSW release for HLT?\ne.g. CMSSW_7_4_9_patch1\nhlt_release [CMSSW_7_4_9_patch1]: ')
 
+                if 'PR' in type:
+                    how_many_workflows = getInput('2','\nHow many workflows do you want to submit?\ntype [2] : ')
+
                 pr_release = getInput('CMSSW_7_4_11_patch1', '\nWhich CMSSW release for Prompt Reco?\ne.g. CMSSW_7_4_11_patch1\npr_release [CMSSW_7_4_11_patch1]: ')
 
                 if 'HLT+RECO' in type:
@@ -163,6 +166,7 @@ I will ask you some questions to fill the metadata file. For some of the questio
                     'PR_release': pr_release,
                     'options': {
                         'Type': type,
+                        'number_of_workflows': how_many_workflows,
                         'newgt': newgt,
                         'gt': gt,
                         'ds': ds,


### PR DESCRIPTION
@franzoni @anorkus @bajarang ,

- We made changes in relval_submit.py where we ask the user the number_of_workflows to run
Here is the metadata.txt file:
_/afs/cern.ch/work/r/rverma/public/2017AlCaVals/toggleAble/wmcontrol/metadata.txt_
- We made changes in condDatasetSubmitter.py which reads the input number_of_workflows and accordingly decides which section to add in the conf file,
e.g.
_./condDatasetSubmitter.py --gt 90X_dataRun2_Prompt_v3 --newgt 90X_dataRun2_Prompt_Cruzet17_w16_2017_v1 --runLs "{u'291871': [[1, 2]]}" **--number_of_workflows 1** --Type PR --ds /Cosmics/Commissioning2017-v1/RAW_ 

Path of conf file:
/afs/cern.ch/work/r/rverma/public/2017AlCaVals/toggleAble/wmcontrol/PRConditionValidation_CMSSW_9_0_1_90X_dataRun2_Prompt_Cruzet17_w16_2017_v1_291871.conf
