### PR TITLE
Decides how many WFs (1 or 2) to run for PROMPT (version 2)

### DIFF
--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -51,6 +51,9 @@ def createOptionParser():
                         help="Defines the type of the workflow",
                         choices=['HLT','PR','PR+ALCA','RECO+HLT','HLT+RECO','HLT+RECO+ALCA'],
                         default='HLT')
+    parser.add_option("--number_of_workflows",
+                        help="Choose the number of workflows required",
+                        default=2)
     parser.add_option("--HLT",
                         help="Specify which default HLT menu: SameAsRun uses the HLT menu corrresponding to the run, Custom lets you choose it explicitly",
                         choices=['SameAsRun','GRun','50nsGRun','Custom','25ns14e33_v3'],
@@ -584,7 +587,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                         'globaltag =%s \n' % (gtshort)
 
     wmcconf_text += 'campaign=%s__ALCARELVAL-%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M")) +\
-                    'acquisition_era=%s\n' % (options.release) 
+                    'acquisition_era=%s\n' % (options.release)
 
     wmcconf_text += 'dset_run_dict= {'
     """
@@ -622,7 +625,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
     elif recodqm:
         pass
     else:
-        for ds in options.ds : 
+        for ds in options.ds :
             ds_name = ds[:1].replace("/","") + ds[1:].replace("/","_")
             ds_name = ds_name.replace("-","_")
             label   = cfgname.lower().replace('.py', '')[0:5]
@@ -653,7 +656,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                 continue
 
             elif recodqm:
-                for ds in options.ds : 
+                for ds in options.ds :
                     ds_name = ds[:1].replace("/","") + ds[1:].replace("/","_")
                     ds_name = ds_name.replace("-","_")
                     label = cfgname.lower().replace('.py', '')[0:5]
@@ -692,7 +695,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
         elif recodqm:
             if "REFERENCE" in cfgname:
                 continue
-            for ds in options.ds : 
+            for ds in options.ds :
                 ds_name = ds[:1].replace("/","") + ds[1:].replace("/","_")
                 ds_name = ds_name.replace("-","_")
                 label = cfgname.lower().replace('.py', '')[0:5]
@@ -718,24 +721,26 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                 wmcconf_text += 'step%d_release = %s \n' % (task,options.recoRelease)
             wmcconf_text += 'harvest_cfg=step4_%s_HARVESTING.py\n\n' % (label)
         else:
-            for ds in options.ds : 
-                ds_name = ds[:1].replace("/","") + ds[1:].replace("/","_")
-                ds_name = ds_name.replace("-","_") 
-                label = cfgname.lower().replace('.py', '')[0:5]
-                wmcconf_text += '\n\n[%s_%s_%s]\n' % (details['reqtype'], label,ds_name) +\
-                                'input_name = %s\n' % (ds) +\
-                                'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
-                                'keep_step1 = True\n' +\
-                                'time_event = 10\n' +\
-                                'size_memory = 3000\n' +\
-                                'step1_lumisperjob = 1\n' +\
-                                'processing_string = %s_%s_%s \n' % (processing_string, details['reqtype']+label, gtshort) +\
-                                'cfg_path = %s\n' % (cfgname) +\
-                                'req_name = %s_%s_RelVal_%s\n' % (details['reqtype'], label, onerun) +\
-                                'globaltag = %s\n' % (gtshort) +\
-                                'harvest_cfg=step4_%s_HARVESTING.py\n\n' % (label)
-    ##END of FOR loop
-
+            if(options.number_of_workflows == '2'):
+                for ds in options.ds :
+                    ds_name = ds[:1].replace("/","") + ds[1:].replace("/","_")
+                    ds_name = ds_name.replace("-","_")
+                    label = cfgname.lower().replace('.py', '')[0:5]
+                    wmcconf_text += '\n\n[%s_%s_%s]\n' % (details['reqtype'], label,ds_name) +\
+                                    'input_name = %s\n' % (ds) +\
+                                    'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
+                                    'keep_step1 = True\n' +\
+                                    'time_event = 10\n' +\
+                                    'size_memory = 3000\n' +\
+                                    'step1_lumisperjob = 1\n' +\
+                                    'processing_string = %s_%s_%s \n' % (processing_string, details['reqtype']+label, gtshort) +\
+                                    'cfg_path = %s\n' % (cfgname) +\
+                                    'req_name = %s_%s_RelVal_%s\n' % (details['reqtype'], label, onerun) +\
+                                    'globaltag = %s\n' % (gtshort) +\
+                                    'harvest_cfg=step4_%s_HARVESTING.py\n\n' % (label)
+                ##END of FOR loop
+            else:
+                continue
     # compose string representing runs, Which will be part of the filename
     # if run is int => single label; if run||runLs are list or dict, '_'-separated composite label
     run_label_for_fn = ''

--- a/relval_submit.py
+++ b/relval_submit.py
@@ -120,6 +120,9 @@ I will ask you some questions to fill the metadata file. For some of the questio
                 if 'HLT+RECO' in type:
                     hlt_release = getInput('CMSSW_7_4_9_patch1', '\nWhich CMSSW release for HLT?\ne.g. CMSSW_7_4_9_patch1\nhlt_release [CMSSW_7_4_9_patch1]: ')
 
+                if 'PR' in type:
+                    how_many_workflows = getInput('2','\nHow many workflows do you want to submit?\ntype [2] : ')
+
                 pr_release = getInput('CMSSW_7_4_11_patch1', '\nWhich CMSSW release for Prompt Reco?\ne.g. CMSSW_7_4_11_patch1\npr_release [CMSSW_7_4_11_patch1]: ')
 
                 if 'HLT+RECO' in type:
@@ -163,6 +166,7 @@ I will ask you some questions to fill the metadata file. For some of the questio
                     'PR_release': pr_release,
                     'options': {
                         'Type': type,
+                        'number_of_workflows': how_many_workflows,
                         'newgt': newgt,
                         'gt': gt,
                         'ds': ds,


### PR DESCRIPTION
@franzoni @anorkus @bajarang ,

We made changes in relval_submit.py where we ask the user the number_of_workflows to run
Here is the metadata.txt file:
/afs/cern.ch/work/r/rverma/public/2017AlCaVals/toggleAble/wmcontrol/metadata.txt
We made changes in condDatasetSubmitter.py which reads the input number_of_workflows and accordingly decides which section to add in the conf file,
e.g.
./condDatasetSubmitter.py --gt 90X_dataRun2_Prompt_v3 --newgt 90X_dataRun2_Prompt_Cruzet17_w16_2017_v1 --runLs "{u'291871': [[1, 2]]}" --number_of_workflows 1 --Type PR --ds /Cosmics/Commissioning2017-v1/RAW
Path of conf file:
/afs/cern.ch/work/r/rverma/public/2017AlCaVals/toggleAble/wmcontrol/PRConditionValidation_CMSSW_9_0_1_90X_dataRun2_Prompt_Cruzet17_w16_2017_v1_291871.conf