### PR TITLE
Added extra era for 2017 dataset and EI, PAT, runUnscheduled options for cmsDriver 

### DIFF
--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -635,7 +635,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
     if (options.runLs):
         wmcconf_text += 'lumi_list=%s\n' % (options.runLs)
 
-    #wmcconf_text+='multicore=4\n'
+    wmcconf_text+='multicore=4\n'
     wmcconf_text += 'enableharvesting = True\n'
     wmcconf_text += 'dqmuploadurl = https://cmsweb.cern.ch/dqm/relval\n'
     wmcconf_text += 'subreq_type = RelVal\n\n'
@@ -657,7 +657,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                             'request_id = %s__ALCARELVAL-%s_%s_refer\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name) +\
                             'keep_step1 = True\n' +\
                             'time_event = 10\n' +\
-                            'size_memory = 3000\n' +\
+                            'size_memory = 6600\n' +\
                             'step1_lumisperjob = 1\n' +\
                             'processing_string = %s_%sref_%s \n' % (processing_string, details['reqtype'], refgtshort) +\
                             'cfg_path = REFERENCE.py\n' +\
@@ -688,7 +688,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                                     'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
                                     'keep_step%d = True\n' % (task) +\
                                     'time_event = 1\n' +\
-                                    'size_memory = 3000\n' +\
+                                    'size_memory = 6600\n' +\
                                     'step1_lumisperjob = 10\n' +\
                                     'processing_string = %s_%s_%s \n' % (processing_string, details['reqtype']+label, refsubgtshort) +\
                                     'cfg_path = %s\n' % (cfgname) +\
@@ -727,7 +727,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                                 'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
                                 'keep_step%d = True\n' % (task) +\
                                 'time_event = 1\n' +\
-                                'size_memory = 3000\n' +\
+                                'size_memory = 6600\n' +\
                                 'step1_lumisperjob = 10\n' +\
                                 'processing_string = %s_%s_%s \n' % (processing_string, details['reqtype']+label, subgtshort) +\
                                 'cfg_path = %s\n' % (cfgname) +\
@@ -754,7 +754,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                                     'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
                                     'keep_step1 = True\n' +\
                                     'time_event = 10\n' +\
-                                    'size_memory = 3000\n' +\
+                                    'size_memory = 6600\n' +\
                                     'step1_lumisperjob = 1\n' +\
                                     'processing_string = %s_%s_%s \n' % (processing_string, details['reqtype']+label, gtshort) +\
                                     'cfg_path = %s\n' % (cfgname) +\

--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -216,13 +216,12 @@ def getCMSSWReleaseFromPath(thePath):
 
 def getDriverDetails(Type, release, ds, B0T, HIon, pA, recoRelease):
     str_era_hlt = 'Run2_2016'
-    print "AAA=======", release
-    if release.find("9_2_0")!= -1:
+    if release.find("9_2_")!= -1:
         for ds_name in ds:
             if ds_name.find("2017")!=-1:
                 str_era_hlt="Run2_2017"
 
-    if recoRelease.find("9_2_0")!= -1:
+    if recoRelease.find("9_2_")!= -1:
         for ds_name in ds:
             if ds_name.find("2017")!=-1:
                 str_era_pr="Run2_2017"

--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -283,7 +283,7 @@ def getDriverDetails(Type, release, ds, B0T, HIon, pA, recoRelease):
                             #"eventcontent":"RAW",
                             "magfield":""})
 
-        HLTRECObase = {"steps":"RAW2DIGI,L1Reco,RECO,DQM",
+        HLTRECObase = {"steps":"RAW2DIGI,L1Reco,RECO,EI,PAT,DQM",
                         "procname":"reRECO",
                         "datatier":"RECO,DQMIO",
                         "eventcontent":"RECO,DQM",
@@ -293,6 +293,7 @@ def getDriverDetails(Type, release, ds, B0T, HIon, pA, recoRelease):
                         "custconditions":'',
                         "customise":'',
                         "era":str_era_hlt,
+                        "runUnscheduled":'',
                         "magfield":"",
                         "dumppython":False}
 
@@ -488,6 +489,8 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                 driver_command += "--customise %s " % (recodqm['customise'])
             if recodqm['era'] != "":
                 driver_command += "--era %s " % (recodqm['era'])
+            if recodqm['runUnscheduled'] == "":
+                driver_command += "--runUnscheduled "
             if recodqm['dumppython']:
                 driver_command += "--dump_python "
             if recodqm['magfield'] != "":
@@ -517,6 +520,9 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                             "--python_filename=step4_%s_HARVESTING.py " % (label) +\
                             "--no_exec " +\
                             "-n 100 "
+
+            if recodqm['era'] != "":
+                driver_command += "--era %s " % (recodqm['era'])
 
             if options.recoCmsswDir:
                 cmssw_command = "cd %s; eval `scramv1 runtime -sh`; cd -" % (options.recoCmsswDir)

--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -507,7 +507,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                 filein = "%s_RAW2DIGI_L1Reco_RECO_ALCA_DQM_inDQM.root" % (details['reqtype'])
             else:
                 filein = "%s_RAW2DIGI_L1Reco_RECO_DQM_inDQM.root" % (details['reqtype'])
-            
+
             driver_command = "cmsDriver.py step4 " +\
                             "-s HARVESTING:dqmHarvesting " +\
                             "--data %s " % (scenario) +\

--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -657,7 +657,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                             'request_id = %s__ALCARELVAL-%s_%s_refer\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name) +\
                             'keep_step1 = True\n' +\
                             'time_event = 10\n' +\
-                            'size_memory = 6600\n' +\
+                            'size_memory = 8000\n' +\
                             'step1_lumisperjob = 1\n' +\
                             'processing_string = %s_%sref_%s \n' % (processing_string, details['reqtype'], refgtshort) +\
                             'cfg_path = REFERENCE.py\n' +\
@@ -688,7 +688,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                                     'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
                                     'keep_step%d = True\n' % (task) +\
                                     'time_event = 1\n' +\
-                                    'size_memory = 6600\n' +\
+                                    'size_memory = 8000\n' +\
                                     'step1_lumisperjob = 10\n' +\
                                     'processing_string = %s_%s_%s \n' % (processing_string, details['reqtype']+label, refsubgtshort) +\
                                     'cfg_path = %s\n' % (cfgname) +\
@@ -727,7 +727,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                                 'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
                                 'keep_step%d = True\n' % (task) +\
                                 'time_event = 1\n' +\
-                                'size_memory = 6600\n' +\
+                                'size_memory = 8000\n' +\
                                 'step1_lumisperjob = 10\n' +\
                                 'processing_string = %s_%s_%s \n' % (processing_string, details['reqtype']+label, subgtshort) +\
                                 'cfg_path = %s\n' % (cfgname) +\
@@ -754,7 +754,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                                     'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
                                     'keep_step1 = True\n' +\
                                     'time_event = 10\n' +\
-                                    'size_memory = 6600\n' +\
+                                    'size_memory = 8000\n' +\
                                     'step1_lumisperjob = 1\n' +\
                                     'processing_string = %s_%s_%s \n' % (processing_string, details['reqtype']+label, gtshort) +\
                                     'cfg_path = %s\n' % (cfgname) +\

--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -507,7 +507,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                 filein = "%s_RAW2DIGI_L1Reco_RECO_ALCA_DQM_inDQM.root" % (details['reqtype'])
             else:
                 filein = "%s_RAW2DIGI_L1Reco_RECO_DQM_inDQM.root" % (details['reqtype'])
-
+            
             driver_command = "cmsDriver.py step4 " +\
                             "-s HARVESTING:dqmHarvesting " +\
                             "--data %s " % (scenario) +\
@@ -541,6 +541,8 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                             "--python_filename=step4_%s_HARVESTING.py " % (label) +\
                             "--no_exec " +\
                             "-n 100 "
+            if details['era'] != "":
+                driver_command += "--era %s " % (details['era'])
 
             execme(driver_command)
     ##END of for loop

--- a/relval_submit.py
+++ b/relval_submit.py
@@ -171,8 +171,9 @@ I will ask you some questions to fill the metadata file. For some of the questio
                         'ds': ds,
                         'run': run}}
                 
-                if(is_PR_after_HLTRECO.lower() == 'n'):
-                    metadata['options'].update({'two_WFs': ''})
+                if 'PR' in type:
+                    if(is_PR_after_HLTRECO.lower() == 'n'):
+                        metadata['options'].update({'two_WFs': ''})
 
                 if runLs:
                     metadata['options']['runLs'] = runLs


### PR DESCRIPTION
@franzoni @arunhep @ravindkv 

I have added the extra era option for the 2017 dataset.
Also the cmsDriver command will be like this for PR 
cmsDriver.py PR -s RAW2DIGI,L1Reco,RECO,EI,PAT,DQM --processName reRECO --data --scenario pp --datatier RECO,DQMIO  --conditions 92X_dataRun2_Prompt_v2 --python_filename REFERENCE.py --no_exec -n 100 --eventcontent RECO,DQM --era Run2_2017 --runUnscheduled 

@anorkus Please wait till Giovanni and Arun confirm. Either they or I will let you know when this is good to go. 

Thanks,
Bajrang