### PR TITLE
Check weather each dataset has enough statistic

### DIFF
--- a/relval_submit.py
+++ b/relval_submit.py
@@ -18,8 +18,7 @@ import optparse
 import json
 import errno
 import ast
-sys.path.insert(0, './modules')
-import wma
+from modules import wma 
 
 def execme(command, dryrun=False):
     '''Wrapper for executing commands.
@@ -222,7 +221,8 @@ I will ask you some questions to fill the metadata file. For some of the questio
                   checkStat_out = checkStat(DataSet, nEvents)
                   print DataSet, 'with RUN', Runs_forcheck, Lumisec_forcheck, 'contains:', nEvents, 'events'
                   if checkStat_out == 'TOO_LOW_STAT':
-                    print 'ERROR! The statistic is too low. I will exit the script.'; sys.exit('POOR_STATISTIC');
+                    print 'ERROR! The statistic is too low. I will exit the script.'
+                    sys.exit('POOR_STATISTIC')
                   elif checkStat_out == 'LOW_STAT':
                     print 'WARNING! The statistic is low. Please check carefully if you do not want to consider a better RUN/lumisection.'
                 b0T = getInput('n', '\nIs this for B=0T?\nAnswer [n]: ')

--- a/relval_submit.py
+++ b/relval_submit.py
@@ -18,7 +18,8 @@ import optparse
 import json
 import errno
 import ast
-from modules.wma import *
+sys.path.insert(0, './modules')
+import wma
 
 def execme(command, dryrun=False):
     '''Wrapper for executing commands.

--- a/relval_submit.py
+++ b/relval_submit.py
@@ -18,10 +18,7 @@ import optparse
 import json
 import errno
 import ast
-#import time
-#from time import gmtime
-#from dbs.apis.dbsClient import DbsApi
-import wma
+from modules.wma import *
 
 def execme(command, dryrun=False):
     '''Wrapper for executing commands.

--- a/relval_submit.py
+++ b/relval_submit.py
@@ -18,6 +18,9 @@ import optparse
 import json
 import errno
 import ast
+import time
+from time import gmtime
+from dbs.apis.dbsClient import DbsApi
 
 def execme(command, dryrun=False):
     '''Wrapper for executing commands.
@@ -63,6 +66,23 @@ def getInputRepeat(prompt=''):
             return answer.strip()
 
         logging.error('You need to provide a value.')
+
+def checkenoughEvents(DataSet, RunNumber, LumiSec):
+  api=DbsApi(url="https://cmsweb.cern.ch/dbs/prod/global/DBSReader")
+  nEventTot=0
+  listFileArray_output = api.listFileArray( dataset=DataSet, run_num=RunNumber, lumi_list=LumiSec, detail=True)
+  for nFile in listFileArray_output:
+    nEvent = nFile['event_count']
+    nEventTot += nEvent
+  return int(nEventTot)
+
+def checkStat(DataSet, nEvents):
+  checkStat_out = ''
+  if nEvents < 30000:
+    checkStat_out = 'TOO_LOW_STAT'
+  elif nEvents < 50000:
+    checkStat_out = 'LOW_STAT'
+  return checkStat_out
 
 def main():
     '''Entry point.
@@ -141,24 +161,40 @@ I will ask you some questions to fill the metadata file. For some of the questio
                 runORrunLs  = getInput('254906', '\nWhich run number or run number+luminosity sections?\ne.g. 254906 or\n     [254906,254905] or\n     {\'256677\': [[1, 291], [293, 390]]}\nrunORrunLs [254906]: ')
                 run = ''
                 runLs = ''
+                runLs_forcheck = ''
+                Lumisec_forcheck = []
                 # do some type recognition and set run or runLs accordingly
                 try:
                     if isinstance(runORrunLs, str) and "{" in runORrunLs :
-                        runLs = ast.literal_eval(runORrunLs)                              # turn a string into a dict and check it's valid
+                        runLs = ast.literal_eval(runORrunLs)                  # turn a string into a dict and check it's valid
+                        Runs_forcheck    = next(iter(runLs))
+                        Lumisec_forcheck = runLs[Runs_forcheck]
                     elif isinstance(runORrunLs, dict):
                         runLs = runORrunLs                                    # keep dict
+                        Runs_forcheck    = next(iter(runLs))
+                        Lumisec_forcheck = runLs[Runs_forcheck]
                     elif isinstance(runORrunLs, str) and "[" in runORrunLs :
-                        run   = ast.literal_eval(runORrunLs)                              # turn a string into a list and check it's valid
+                        run = ast.literal_eval(runORrunLs)                    # turn a string into a list and check it's valid
+                        Runs_forcheck = run
                     elif isinstance(runORrunLs, str) :
                         run = int(runORrunLs)                                 # turn string into int
+                        Runs_forcheck = run
                     elif isinstance(runORrunLs, list):
                         run = runORrunLs                                      # keep list
+                        Runs_forcheck = run
                     else:
                         raise ValueError(run_err_mess)
                 except ValueError:
                     logging.error(run_err_mess)
-
-
+      
+                for DataSet in ds.split(","):                                  # check if you have enough events in each dataset
+                  nEvents = checkenoughEvents(DataSet, Runs_forcheck, Lumisec_forcheck)
+                  checkStat_out = checkStat(DataSet, nEvents)
+                  print DataSet, 'with RUN', Runs_forcheck, Lumisec_forcheck, 'contains:', nEvents, 'events'
+                  if checkStat_out == 'TOO_LOW_STAT':
+                    print 'ERROR! The statistic is too low. I will exit the script.'; sys.exit('POOR_STATISTIC');
+                  elif checkStat_out == 'LOW_STAT':
+                    print 'WARNING! The statistic is low. Please check carefully if you do not want to consider a better RUN/lumisection.'
                 b0T = getInput('n', '\nIs this for B=0T?\nAnswer [n]: ')
                 hion = getInput('n', '\nIs this for Heavy Ions? Note B=0T is not compatible with Heavy Ions at the moment, also pA runs and Heavy Ions runs are mutually exclusive\nAnswer [n]: ')
                 pa_run   = getInput('n', '\nIs this for pA run?\nAnswer [n]:')


### PR DESCRIPTION
As you can see for each dataset-RUN-LS it returns the total Nevents. It returns an ERROR if Nev. is too low, and just a warning is the number is low.

Few (Important) Notes:
1) In case the dataset-RUN-LS are not available on the database, it will stop the user with an error (main feature we want)

2) If a single file contains a wanted LS, but also a non wanted LS, it will count anyway the total number of events in the file. This could bias the results toward greater Nev.
    -> I compared the output of the new feature with the Nevent expected looking at the rate for each lumisection
    -> It seems that a file could contain easily up to 30 lumisections (at least in run 297675)
         -> This mean that if you want to return the Nevents for a single lumisection, you could get ~30 times times more event than the expected value
         -> BUT In case that you need the Nevent in a consequential interval of 300 lumisection, the final number is accurate (within 10%). This is because the lumisections you want are consecutive and they are all in the same file. Basically, only the 2 extreme lumisections will introduce extra-events in the count.
    -> As a consequence the Number of Events is fairly accurate for request of lumisections like [a,b], where a and b are distant, and very inaccurate if you ask for [a,b],[c,d],[e,f] (for many small intervals distant from each others).

3) So far below 30k events we exit with an error (’ TOO_LOW_STAT’), and below 50k events we only send a warning ('LOW_STAT')
    -> This could be improved. We could add there a matrix that for each PD provides a different minimum number of events allowed.

4) We inform anyway the user of the number of events per dataset 

Let me know what you think.
I believe that 1) is the most useful feature we want to implement. 
About 2): I believe RELVAL are generally submitted in a single lumisection interval (like [1,300]) where the counting is correct ~10%.
If you prefer do not have any counting of events at all, I could descope the fix, and just add an error if the number of events zero or below a threshold.
Personally I’m fine with PR the code as it is. Maybe, I could add a caveat in the Nevent printout that warnins the user that the number could be biased in the case just mentioned.

