### PR TITLE
add JIRA ticket number in campaign ID

### DIFF
--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -25,6 +25,9 @@ def createOptionParser():
     """
 
     parser = OptionParser(usage)
+    parser.add_option("--jira",
+                        dest="jira",
+                        help="jira ticket, where validation will take place")
     parser.add_option("--newgt",
                         dest="newgt",
                         help="new global tag containing tag to be tested")
@@ -438,7 +441,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
             driver_command += "--era %s " % (details['era'])
         if options.Type in ['PR', 'PR+ALCA']:
             if details['runUnscheduled'] == "":
-                driver_command += "--runUnscheduled " 
+                driver_command += "--runUnscheduled "
         if details['magfield'] != "":
             driver_command += '--magField %s ' % (details['magfield'])
         if details['inputcommands'] != "":
@@ -610,7 +613,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                         'release=%s\n' % (options.release) +\
                         'globaltag =%s \n' % (gtshort)
 
-    wmcconf_text += 'campaign=%s__ALCARELVAL-%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M")) +\
+    wmcconf_text += 'campaign=%s__ALCA_%s-%s\n' % (options.release,options.jira,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M")) +\
                     'acquisition_era=%s\n' % (options.release)
 
     """
@@ -654,7 +657,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
             label   = cfgname.lower().replace('.py', '')[0:5]
             wmcconf_text += '[%s_reference_%s]\n' % (details['reqtype'],ds_name) +\
                             'input_name = %s\n' % (ds) +\
-                            'request_id = %s__ALCARELVAL-%s_%s_refer\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name) +\
+                            'request_id = %s__ALCA_%s-%s_%s_refer\n' % (options.release,options.jira,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name) +\
                             'keep_step1 = True\n' +\
                             'time_event = 10\n' +\
                             'size_memory = 8000\n' +\
@@ -685,7 +688,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                     label = cfgname.lower().replace('.py', '')[0:5]
                     wmcconf_text += '\n[%s_%s_%s]\n' % (details['reqtype'], label, ds_name) +\
                                     'input_name = %s\n' % (ds) +\
-                                    'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
+                                    'request_id=%s__ALCA_%s-%s_%s_%s\n' % (options.release,options.jira,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
                                     'keep_step%d = True\n' % (task) +\
                                     'time_event = 1\n' +\
                                     'size_memory = 8000\n' +\
@@ -724,7 +727,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                 label = cfgname.lower().replace('.py', '')[0:5]
                 wmcconf_text += '\n\n[%s_%s_%s]\n' %(details['reqtype'], label, ds_name) +\
                                 'input_name = %s\n' % (ds) +\
-                                'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
+                                'request_id=%s__ALCA_%s-%s_%s_%s\n' % (options.release,options.jira,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
                                 'keep_step%d = True\n' % (task) +\
                                 'time_event = 1\n' +\
                                 'size_memory = 8000\n' +\
@@ -751,7 +754,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                     label = cfgname.lower().replace('.py', '')[0:5]
                     wmcconf_text += '\n\n[%s_%s_%s]\n' % (details['reqtype'], label,ds_name) +\
                                     'input_name = %s\n' % (ds) +\
-                                    'request_id=%s__ALCARELVAL-%s_%s_%s\n' % (options.release,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
+                                    'request_id=%s__ALCA_%s-%s_%s_%s\n' % (options.release,options.jira,datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"),ds_name,label) +\
                                     'keep_step1 = True\n' +\
                                     'time_event = 10\n' +\
                                     'size_memory = 8000\n' +\

--- a/relval_submit.py
+++ b/relval_submit.py
@@ -18,7 +18,7 @@ import optparse
 import json
 import errno
 import ast
-from modules import wma 
+from modules import wma
 
 def execme(command, dryrun=False):
     '''Wrapper for executing commands.
@@ -151,6 +151,7 @@ I will ask you some questions to fill the metadata file. For some of the questio
                     hlt_menu = getInput('orcoff:/cdaq/physics/Run2015/25ns14e33/v3.5/HLT/V7', '\nWhich HLT menu?\ne.g. orcoff:/cdaq/physics/Run2015/25ns14e33/v3.5/HLT/V7\nhlt_menu [orcoff:/cdaq/physics/Run2015/25ns14e33/v3.5/HLT/V7]: ')
 
                 newgt = getInput('74X_dataRun2_HLTValidation_2015-09-07-08-26-15', '\nWhat is the new GT to be validated?\ne.g. 74X_dataRun2_HLTValidation_2015-09-07-08-26-15\nnewgt [74X_dataRun2_HLTValidation_2015-09-07-08-26-15]: ')
+                jira = getInput('0', '\nWhat is the JIRA ticket number?\ne.g. 10\njira [10]:')
 
                 gt = getInput('74X_dataRun2_HLT_v1', '\nWhat is the reference GT?\ne.g. 74X_dataRun2_HLT_v1\ngt [74X_dataRun2_HLT_v1]: ')
 
@@ -213,7 +214,7 @@ I will ask you some questions to fill the metadata file. For some of the questio
                         raise ValueError(run_err_mess)
                 except ValueError:
                     logging.error(run_err_mess)
-      
+
                 for DataSet in ds.split(","):                                  # check if you have enough events in each dataset
                   print Runs_forcheck
                   print Lumisec_forcheck
@@ -232,11 +233,12 @@ I will ask you some questions to fill the metadata file. For some of the questio
                     'PR_release': pr_release,
                     'options': {
                         'Type': type,
+                        'jira': jira,
                         'newgt': newgt,
                         'gt': gt,
                         'ds': ds,
                         'run': run}}
-                
+
                 if 'PR' in type:
                     if(is_PR_after_HLTRECO.lower() == 'n'):
                         metadata['options'].update({'two_WFs': ''})


### PR DESCRIPTION
Hi @anorkus, @franzoni, @lpernie, @arunhep @bajarang 

We have modified relval_submit.py and condDatasetSubmitter.py scripts to add JIRA ticket number in the campaign ID. 
For example, the old campaign ID was:
CMSSW_9_2_0_patch5__ALCARELVAL-2017_06_09_07_47
The new one will look like:
CMSSW_9_2_0_patch5__ALCA_X-2017_06_09_07_47

Where "X" is related to the JIRA ticket number. For https://its.cern.ch/jira/browse/CMSALCA-25, X =25.  We have moved the validation on JIRA, that's why we are adding it to the campaign ID.

Thanks a lot.
Bajarang and Ravindra