### PR TITLE
Avoid to use shell instructions to perform HTTP request

### DIFF
--- a/modules/http_client.py
+++ b/modules/http_client.py
@@ -1,0 +1,204 @@
+"""
+Auxiliary module to perform HTTP requests
+and parse the result.
+"""
+try:
+    import httplib
+except ImportError:
+    import http.client as httplib
+
+import sys
+import ssl
+import re
+import json
+import time
+from modules import logger as logger_factory
+
+# Some constants
+URL_PARSER_REGEX = r'^(http[s]?)://([a-z|A-Z|.|-]+)(:[0-9]{3,5})?(/[^\n ]*$)'
+url_parser = re.compile(URL_PARSER_REGEX)
+logger = logger_factory.create_logger()
+
+
+def __parse_url(url):
+    """
+    Parses the http schema, hostname, port and resource
+    for a given URL.
+
+    Args:
+        url (str): URL to parse
+    Returns:
+        tuple (str): A tuple indicating the HTTP schema,
+            hostname, port and resource to consume.
+    Raises:
+        ValueError: If it is not possible to parse the required
+            element from the given URL.
+    """
+    result = url_parser.findall(url)
+    if not result:
+        msg = (
+            'Unable to parse the given URL: %s - Regex used: %s'
+            % (url, URL_PARSER_REGEX)
+        )
+        raise ValueError(msg)
+    
+    components = result[0]
+    schema, hostname, port, resource =  components
+    port = port.replace(":", "", 1)
+
+    # Some encodings for the resource
+    resource = resource.replace("#", "%23")
+
+    return (schema, hostname, port, resource)
+
+def http_request(
+        url, 
+        method, 
+        retries=2, 
+        timeout=60,
+        headers={}, 
+        data={}, 
+        cert_file=None, 
+        key_file=None,
+        raise_on_failure=True
+    ):
+    """
+    Consumes a resource using the HTTP protocol and parses its result.
+
+    Args:
+        url (str): Resource URL.
+        method (str): HTTP request method, e.g: GET, POST, PUT.
+        retries (int): In case of failures, how many times the request
+            is going to be retried.
+        timeout (int): HTTP request timeout, in seconds.
+        headers (dict[str, str]): HTTP request headers.
+        data (dict | str): HTTP request data, if required.
+        cert_file (str): Path to the certificate used in SSL authentication
+            This is optional.
+        cert_file (str): Path to the key file used in SSL authentication
+            This is optional.
+        raise_on_failure (bool): Determines if an exception is raised
+            if there is a failure consuming the HTTP resource.
+    
+    Returns:
+        dict | bytes: HTTP response content.
+    
+    Raises:
+        ValueError: If there are issues parsing the URL or the data
+            for performing the HTTP request. Also, if they are issues
+            parsing the response data.
+        RuntimeError: Error consuming the resource from the server.
+    """
+    MAX_ATTEMPTS_TO_DICT = 5
+    default_headers = {
+        'Content-type': 'application/json',
+        'Accept': 'application/json'
+    }
+    req_headers = default_headers if not headers else headers
+    json_response = req_headers.get('Accept', '') == 'application/json'
+    http_schema, hostname, port, resource = __parse_url(url)
+    is_https = http_schema == 'https'
+
+    # Parse HTTP request data
+    req_data = None if not data else data
+    if req_data:
+        if isinstance(req_data, dict):
+            req_data = json.dumps(req_data)
+        if not isinstance(req_data, str):
+            error_msg = (
+                "Please encode your request data as 'str'. "
+                "Also make sure to provide the appropiate headers"
+            )
+            raise ValueError(error_msg)
+        
+    # Parse the port properly
+    if port:
+        port = port.replace(":", "", 1)
+        port = int(port)
+    else:
+        port = 443 if is_https else 80
+
+    # Build the connection params
+    connection_params = {
+        "host": hostname,
+        "port": port,
+        "timeout": timeout,
+    }
+    if cert_file and key_file:
+        connection_params["cert_file"] = cert_file
+        connection_params["key_file"] = key_file
+    
+    # Perform the request.
+    last_attempt_exception = None
+    for _ in range(retries):
+        try:
+            # Create the connection
+            if is_https:
+                conn = httplib.HTTPSConnection(**connection_params)
+            else:
+                conn = httplib.HTTPConnection(**connection_params)
+
+            # Consume the resource
+            conn.request(method, resource, req_data, req_headers)
+            response = conn.getresponse()
+            status, res = response.status, response.read()
+            conn.close()
+
+            if status == 200:
+                if json_response:
+                    res_as_dict = res.decode("utf-8")
+
+                    # Parse as a Python object
+                    for _ in range(MAX_ATTEMPTS_TO_DICT):
+                        res_as_dict = json.loads(res_as_dict)
+                        if isinstance(res_as_dict, dict):
+                            break
+                    if not isinstance(res_as_dict, dict):
+                        error_msg = (
+                            "Unable to parse the response as a dict after %d attempts"
+                            % (MAX_ATTEMPTS_TO_DICT)
+                        )
+                        raise ValueError(error_msg)
+
+                    return res_as_dict
+                else:
+                    logger.warning("Returning response as bytes")
+                    return res
+
+            # Invalid code
+            logger.error('Invalid status code:\n Status: %s, \n Response: %s', status, res)
+            time.sleep(1)
+        except Exception as e:
+            last_attempt_exception = e
+            logger.error('Error performing HTTP request to: %s', url)
+            logger.error('Description: %s', e)
+            if is_https and not connection_params.get("context"):
+                logger.warning('Disabling server certificate validation')
+                no_cert_validation = ssl._create_unverified_context()
+                no_cert_validation.set_ciphers('DEFAULT')
+                connection_params["context"] = no_cert_validation
+
+                if isinstance(last_attempt_exception, ssl.SSLError):
+                    # Reset the exception.
+                    last_attempt_exception = None
+
+    # Unable to retrieve the requested resource
+    error_msg = (
+        "Unable to consume the HTTP resource: %s \n"
+        "Method: %s \n" 
+        % (url, method)
+    )
+    logger.error(error_msg)
+    if not raise_on_failure:
+        return None
+    if (
+        last_attempt_exception 
+        and isinstance(last_attempt_exception, Exception)
+    ):
+        logger.critical(
+            "Exception chained - Type: %s - Message: %s",
+            type(last_attempt_exception),
+            last_attempt_exception,
+        )
+
+    raise RuntimeError(error_msg)

--- a/modules/logger.py
+++ b/modules/logger.py
@@ -1,0 +1,34 @@
+"""
+Manages the logger configuration.
+
+Most of the modules in this code base are used in embedding
+batch jobs, therefore, only enable handlers to
+the standard output.
+"""
+import logging
+import sys
+
+def create_logger(level=logging.INFO):
+    """
+    Creates a logger.
+
+    Args:
+        level (int): Logger's level
+    Returns:
+        logging.Logger: Logger to records events in
+            the standard output.
+    """
+    logger = logging.getLogger(__name__)
+    date_fmt = '%Y-%m-%d %H:%M:%S %z'
+    logging_fmt = (
+        '[%(levelname)s][%(filename)s]'
+        '[%(asctime)s]: %(message)s'
+    )
+    logger_format = logging.Formatter(fmt=logging_fmt, datefmt=date_fmt)
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(level=level)
+    console_handler.setFormatter(fmt=logger_format)
+
+    logger.handlers = []
+    logger.addHandler(console_handler)
+    return logger

--- a/tests/modules/http_client.py
+++ b/tests/modules/http_client.py
@@ -1,0 +1,146 @@
+"""
+This module checks that 'modules/http_client.py' works
+properly.
+"""
+import unittest
+from modules import http_client, logger as logger_factory
+
+
+class BaseTest(unittest.TestCase):
+    """
+    Sets up different scenarios to test
+    the HTTP client.
+    """
+
+    def setUp(self):
+        """
+        Prepare the test scenarios.
+        """
+        self.logger = logger_factory.create_logger()
+        self.valid_public_url = (
+            "https://cms-pdmv-prod.web.cern.ch"
+            "/mcm/public/restapi/requests/get_dict/B2G-RunIISummer20UL17NanoAODv9-03570"
+        )
+        self.invalid_by_redirection = (
+            "https://cms-pdmv.cern.ch"
+            "/mcm/public/restapi/requests/get_dict/B2G-RunIISummer20UL17NanoAODv9-03570"
+        )
+        self.invalid_by_auth = (
+            "https://cms-pdmv-prod.web.cern.ch"
+            "/mcm/restapi/requests/get/B2G-RunIISummer20UL17NanoAODv9-03570"
+        )
+        self.invalid_url_pattern = (
+            "ws://cms-pdmv-prod.web.cern.ch"
+            "/mcm/public/restapi/requests/get_dict/B2G-RunIISummer20UL17NanoAODv9-03570"
+        )
+        self.http_url = 'http://info.cern.ch/hypertext/WWW/TheProject.html'
+        self.headers_for_bytes_response = {
+            'Content-type': 'application/json'
+        }
+        self.headers_for_plain_response = {
+            'Content-type': 'text/html'
+        }
+    
+    def test_public_resource(self):
+        """
+        Consume a public resource that doesn't require any kind
+        of authentication.
+        """
+        response = http_client.http_request(url=self.valid_public_url, method="GET")
+        expected_requestor = "pdmvserv"
+        expected_group = "ppd"
+        self.assertIsInstance(
+            response, 
+            dict, 
+            "The response content has not the type required"
+        )
+        self.assertEqual(
+            expected_requestor, 
+            response.get("Requestor", ""), 
+            "The 'Requestor' field doesn't match"
+        )
+        self.assertEqual(
+            expected_group, 
+            response.get("Group", ""), 
+            "The 'Group' field doesn't match"
+        )
+
+
+    def test_server_issues(self):
+        """
+        Consume a HTTP endpoint that doesn't
+        return a HTTP 200 response and raises issues.
+        """
+        def __consume_resource():
+            """
+            The client raises a RuntimeError due to
+            a HTTP 301 response that ask the user to
+            consume the resource from the new domain.
+            """
+            _ = http_client.http_request(url=self.invalid_by_redirection, method="GET")
+        
+        self.assertRaises(RuntimeError, __consume_resource)
+
+    
+    def test_authentication_issues(self):
+        """
+        Consume a HTTP endpoint that doesn't
+        return a HTTP 200 response and raises issues
+        related to authentication.
+        """
+        def __consume_resource():
+            """
+            The client raises a RuntimeError due to
+            a HTTP 302 response that sends the user
+            to the CERN SSO login page.
+            """
+            _ = http_client.http_request(url=self.invalid_by_auth, method="GET")
+        
+        self.assertRaises(RuntimeError, __consume_resource)
+
+
+    def test_invalid_url(self):
+        """
+        Attempts to consume a HTTP resource with an invalid URL.
+        """
+        def __consume_resource():
+            """
+            The client raises a ValueError due to
+            the URL is invalid.
+            """
+            _ = http_client.http_request(url=self.invalid_url_pattern, method="GET")
+        
+        self.assertRaises(ValueError, __consume_resource)
+
+    
+    def test_bytes_return(self):
+        """
+        Consume a HTTP resource and checks that the returned
+        data is a 'bytes' value.
+        """
+        response = http_client.http_request(
+            url=self.valid_public_url, 
+            method="GET",
+            headers=self.headers_for_bytes_response
+        )
+        self.assertIsInstance(
+            response, 
+            bytes, 
+            "The response content has not the type required"
+        )
+
+    
+    def test_http_request(self):
+        """
+        Check that it is possible to consume HTTP
+        pages, without TLS.
+        """
+        response = http_client.http_request(
+            url=self.http_url, 
+            method="GET",
+            headers=self.headers_for_plain_response
+        )
+        response_str = response.decode("utf-8")
+        self.assertIsInstance(response, bytes, "The response content has not the type required")
+        self.assertIn("The World Wide Web project", response_str)
+

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,19 @@
+"""
+This module groups all the test cases and enables to execute
+all of them. Just import the test into the namespace
+"""
+import os
+import sys
+import unittest
+
+# Support for Python 2
+try:
+    from tests.modules.http_client import BaseTest
+except ImportError:
+    sys.path.append(os.path.join(sys.path[0], 'modules'))
+    from http_client import BaseTest
+
+if __name__ == "__main__":
+    print("Python version: ", sys.version)
+    print("\n")
+    unittest.main(verbosity=2)

--- a/wmcontrol.py
+++ b/wmcontrol.py
@@ -30,6 +30,7 @@ import ast
 
 sys.path.append(os.path.join(sys.path[0], 'modules'))
 from modules import helper
+from modules import http_client
 from modules import wma # here u have all the components to interact with the wma
 
 #-------------------------------------------------------------------------------
@@ -902,7 +903,7 @@ def build_params_dict(section,cfg):
     ##if we fetch the dictionary fro 3rd party source
     if url_dict != "":
         #print "This is the url",url_dict,"to get the dict from"
-        params = json.loads(os.popen('curl -s --insecure %s' % (url_dict)).read())
+        params = http_client.http_request(url=url_dict, method="GET")
         #print params
         service_params["request_type"] = params["RequestType"]
         service_params["version"] = params["ProcessingVersion"]


### PR DESCRIPTION
1. Remove the use of cURL instructions to consume resources from McM.
2. Include a HTTP client module compatible with Python versions [2.7, 3.11].
3. Include unit tests to check the behavior for this new module.