### PR TITLE
Patch the split strategy for requests having `events < 0`

### DIFF
--- a/modules/helper.py
+++ b/modules/helper.py
@@ -68,7 +68,7 @@ class SubsetByLumi():
                 res = []
                 for d in data:
                     res.append(d['name'])
-                return ('blocks', map(lambda x: x.encode('ascii'), res))
+                return ('blocks', list(map(lambda x: x.encode('ascii'), res)))
             print("Block based splitting not enough. Trying with lumis.")
 
         # get files per dataset

--- a/modules/helper.py
+++ b/modules/helper.py
@@ -43,6 +43,8 @@ class SubsetByLumi():
         brute -- if brute force
         only_lumis -- skip trying to split by block
         """
+        if events <= 0:
+            return ('dataset', self.dataset)
 
         if not only_lumis:
             # try with blocks first

--- a/modules/wma.py
+++ b/modules/wma.py
@@ -17,6 +17,7 @@ import sys
 import time
 import codecs
 import json
+import traceback
 # Lightweight helpers for upload to ReqMgr2
 from modules.tweak_maker_lite import TweakMakerLite
 from modules.config_cache_lite import ConfigCacheLite
@@ -78,6 +79,7 @@ class ConnectionWrapper():
             except Exception:
                 # most likely connection terminated
                 self.refresh_connection(self.wmagenturl)
+                traceback.print_exc()
         try:
             return json.loads(res)
         except:

--- a/wmcontrol.py
+++ b/wmcontrol.py
@@ -517,15 +517,15 @@ def loop_and_submit(cfg):
                         else:
                             __events = float(params[__first_step]['RequestNumEvents'])
 
-                        split, details = espl.run(int(__events),
-                              service_params['brute_force'], service_params['force_lumis'])
-
                         ##if we do block selection this means we need to remove the RequestNumEvents
                         # because reqmgr2 doesn't allow events with input dataset
                         if 'RequestNumEvents' in params:
                             del(params['RequestNumEvents'])
                         if 'RequestNumEvents' in params[__first_step]:
                             del(params[__first_step]['RequestNumEvents'])
+
+                        split, details = espl.run(int(__events),
+                              service_params['brute_force'], service_params['force_lumis'])
 
                         if split == 'blocks':
                             params[__first_step]['BlockWhitelist'] = details


### PR DESCRIPTION
The context of this PR is related to injecting the request [EXO-Run3Summer22MiniAODv4-00662](https://cms-pdmv-prod.web.cern.ch/mcm/requests?prepid=EXO-Run3Summer22MiniAODv4-00662&page=0&shown=127). It was required to set  `dataset` as the split strategy when setting `-1` to the number of events.